### PR TITLE
Implement offset/limit correctly

### DIFF
--- a/microcosm_propertygraph/stores/base.py
+++ b/microcosm_propertygraph/stores/base.py
@@ -1,0 +1,44 @@
+"""
+Persistence idioms.
+
+"""
+from abc import ABCMeta, abstractmethod
+from itertools import islice
+
+
+class Store(metaclass=ABCMeta):
+    """
+    Read-only access to a collection of resources.
+
+    """
+    def __init__(self, graph, model_class):
+        self.model_class = model_class
+
+    @abstractmethod
+    def count(self, **kwargs):
+        pass
+
+    @abstractmethod
+    def search(self, offset, limit, **kwargs):
+        pass
+
+
+class NaiveStore(Store):
+    """
+    A naive store implementation that uses a single iterator.
+
+    """
+    def count(self, **kwargs):
+        return sum(1 for n in self.iter_items(**kwargs))
+
+    def search(self, offset=0, limit=None, **kwargs):
+        items = self.iter_items(**kwargs)
+
+        if limit is None:
+            return islice(items, offset, None)
+
+        return islice(items, offset, offset + limit)
+
+    @abstractmethod
+    def iter_items(self, **kwargs):
+        pass

--- a/microcosm_propertygraph/stores/node_store.py
+++ b/microcosm_propertygraph/stores/node_store.py
@@ -1,33 +1,23 @@
 """
-Node store.
+Node persistence.
 
 """
-from abc import ABCMeta, abstractmethod
-from itertools import islice
-
-from microcosm_postgres.store import Store
+from microcosm_propertygraph.stores.base import NaiveStore, Store
 from microcosm_propertygraph.models.node import Node
 
 
-class NodeStoreBase(Store, metaclass=ABCMeta):
+class NodeStore(Store):
+    """
+    Read-only access to the collection of all nodes.
 
-    def __init__(self, graph, model_class=Node):
-        super(NodeStoreBase, self).__init__(graph, model_class)
+    """
+    def __init__(self, graph=None, model_class=Node):
+        super().__init__(graph, model_class)
 
-    def count(self, **kwargs):
-        return sum(1 for n in self.iter_nodes(**kwargs))
 
-    def search(self, offset, limit, **kwargs):
-        return islice(
-            self.iter_nodes(**kwargs),
-            offset,
-            limit,
-        )
+class NaiveNodeStore(NaiveStore, NodeStore):
+    """
+    Node store implementation using a single iterator.
 
-    @abstractmethod
-    def iter_nodes(self, **kwargs):
-        """
-        Iterate over `Node` instances. Derived classes will need to implement logic here
-        to materialize data required and yield Node instances.
-
-        """
+    """
+    pass

--- a/microcosm_propertygraph/stores/relationship_store.py
+++ b/microcosm_propertygraph/stores/relationship_store.py
@@ -2,34 +2,22 @@
 Relationship store.
 
 """
-from abc import ABCMeta, abstractmethod
-from itertools import islice
-
-from microcosm_postgres.store import Store
+from microcosm_propertygraph.stores.base import NaiveStore, Store
 from microcosm_propertygraph.models.relationship import Relationship
 
 
-class RelationshipStoreBase(Store, metaclass=ABCMeta):
+class RelationshipStore(Store):
+    """
+    Read-only access to the collection of all relationships.
 
-    def __init__(self, graph, model_class=Relationship):
-        super(RelationshipStoreBase, self).__init__(graph, model_class)
-        self.assertion_store = graph.assertion_store
-        self.inferred_assertion_store = graph.inferred_assertion_store
+    """
+    def __init__(self, graph=None, model_class=Relationship):
+        super().__init__(graph, model_class)
 
-    def count(self, **kwargs):
-        return sum(1 for n in self.iter_relationships(**kwargs))
 
-    def search(self, offset, limit, **kwargs):
-        return islice(
-            self.iter_relationships(**kwargs),
-            offset,
-            limit,
-        )
+class NaiveRelationshipStore(NaiveStore, RelationshipStore):
+    """
+    Relationship store implementation using a single iterator.
 
-    @abstractmethod
-    def iter_relationships(self, **kwargs):
-        """
-        Iterate over `Relationship` instances. Derived classes will need to implement logic here
-        to materialize data required and yield Relationship instances.
-
-        """
+    """
+    pass

--- a/microcosm_propertygraph/tests/stores/test_node_store.py
+++ b/microcosm_propertygraph/tests/stores/test_node_store.py
@@ -1,0 +1,77 @@
+"""
+Node store tests.
+
+"""
+from hamcrest import (
+    assert_that,
+    contains,
+    equal_to,
+    has_properties,
+    is_,
+)
+
+from microcosm_propertygraph.stores.node_store import NaiveNodeStore
+
+
+class ExampleNodeStore(NaiveNodeStore):
+
+    def iter_items(self, **kwargs):
+        yield self.model_class(
+            id="1",
+            labels=["label"],
+            properties={},
+        )
+        yield self.model_class(
+            id="2",
+            labels=["label"],
+            properties={},
+        )
+        yield self.model_class(
+            id="3",
+            labels=["label"],
+            properties={},
+        )
+
+
+class TestNodeStore:
+
+    def setup(self):
+        self.store = ExampleNodeStore()
+
+    def test_count(self):
+        assert_that(self.store.count(), is_(equal_to(3)))
+
+    def test_search(self):
+        assert_that(
+            self.store.search(),
+            contains(
+                has_properties(id="1"),
+                has_properties(id="2"),
+                has_properties(id="3"),
+            ),
+        )
+
+    def test_search_limit(self):
+        assert_that(
+            self.store.search(limit=1),
+            contains(
+                has_properties(id="1"),
+            ),
+        )
+
+    def test_search_offset(self):
+        assert_that(
+            self.store.search(offset=1),
+            contains(
+                has_properties(id="2"),
+                has_properties(id="3"),
+            ),
+        )
+
+    def test_search_offset_limit(self):
+        assert_that(
+            self.store.search(offset=1, limit=1),
+            contains(
+                has_properties(id="2"),
+            ),
+        )

--- a/microcosm_propertygraph/tests/stores/test_relationship_store.py
+++ b/microcosm_propertygraph/tests/stores/test_relationship_store.py
@@ -1,0 +1,80 @@
+"""
+Relationship store tests.
+
+"""
+from hamcrest import (
+    assert_that,
+    contains,
+    equal_to,
+    has_properties,
+    is_,
+)
+
+from microcosm_propertygraph.stores.relationship_store import NaiveRelationshipStore
+
+
+class ExampleRelationshipStore(NaiveRelationshipStore):
+
+    def iter_items(self, **kwargs):
+        yield self.model_class(
+            start_id="1",
+            end_id="2",
+            type=["foo"],
+            properties={},
+        )
+        yield self.model_class(
+            start_id="2",
+            end_id="3",
+            type=["foo"],
+            properties={},
+        )
+        yield self.model_class(
+            start_id="3",
+            end_id="1",
+            type=["foo"],
+            properties={},
+        )
+
+
+class TestRelationshipStore:
+
+    def setup(self):
+        self.store = ExampleRelationshipStore()
+
+    def test_count(self):
+        assert_that(self.store.count(), is_(equal_to(3)))
+
+    def test_search(self):
+        assert_that(
+            self.store.search(),
+            contains(
+                has_properties(start_id="1"),
+                has_properties(start_id="2"),
+                has_properties(start_id="3"),
+            ),
+        )
+
+    def test_search_limit(self):
+        assert_that(
+            self.store.search(limit=1),
+            contains(
+                has_properties(start_id="1"),
+            ),
+        )
+
+    def test_search_offset(self):
+        assert_that(
+            self.store.search(offset=1),
+            contains(
+                has_properties(start_id="2"),
+                has_properties(start_id="3"),
+            ),
+        )
+
+    def test_search_offset_limit(self):
+        assert_that(
+            self.store.search(offset=1, limit=1),
+            contains(
+                has_properties(start_id="2"),
+            ),
+        )


### PR DESCRIPTION
Several fixes:
 -  Stop depending on `microcosm-postgres` (which is not a dependency)
 -  Implement common store abstractions; add store tests
 -  Use `islice` correctly (start/stop vs offset/limit)